### PR TITLE
Replace dots on logger

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 deadlock_retry changes
 
+== v1.3.0
+
+* Do not use dots on logs, use :: instead
+
 == v1.2.0
 
 * Support for postgres (tomhughes)

--- a/lib/deadlock_retry.rb
+++ b/lib/deadlock_retry.rb
@@ -93,7 +93,7 @@ module DeadlockRetry
     end
 
     def log(retry_count)
-      rails_logger.warn "retry_tx.attempt=#{retry_count} retry_tx.max_attempts=#{MAX_RETRIES_ON_STATEMENT_INVALID} retry_tx.opentransactions=#{open_transactions} retry_tx.innodbstatusb64=#{base64_innodb_status}"
+      rails_logger.warn "retry_tx_attempt=#{retry_count} retry_tx_max_attempts=#{MAX_RETRIES_ON_STATEMENT_INVALID} retry_tx_opentransactions=#{open_transactions} retry_tx_innodbstatusb64=#{base64_innodb_status}"
     end
 
     def rails_logger

--- a/lib/deadlock_retry/version.rb
+++ b/lib/deadlock_retry/version.rb
@@ -1,3 +1,3 @@
 module DeadlockRetry
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end

--- a/test/deadlock_retry_test.rb
+++ b/test/deadlock_retry_test.rb
@@ -111,7 +111,7 @@ class DeadlockRetryTest < MiniTest::Test
   def test_failure_logging
     mock_logger = mock
     MockModel.expects(:rails_logger).returns(mock_logger)
-    mock_logger.expects(:warn).with("retry_tx.attempt=1 retry_tx.max_attempts=5 retry_tx.opentransactions=0 retry_tx.innodbstatusb64=MTYwN2JmMDAwIElOTk9EQiBNT05JVE9SIE9VVFBVVA==")
+    mock_logger.expects(:warn).with("retry_tx_attempt=1 retry_tx_max_attempts=5 retry_tx_opentransactions=0 retry_tx_innodbstatusb64=MTYwN2JmMDAwIElOTk9EQiBNT05JVE9SIE9VVFBVVA==")
     errors = [ TIMEOUT_ERROR ]
     assert_equal :success, MockModel.transaction { raise ActiveRecord::StatementInvalid, errors.shift unless errors.empty?; :success }
     assert errors.empty?


### PR DESCRIPTION
Fixes bebanjo/chef-repo#903. We use `_`
to replace dots, as they won't break Elasticsearch indexing.
